### PR TITLE
ipmc/l2mc support multi-NPU

### DIFF
--- a/inc/saiipmcgroup.h
+++ b/inc/saiipmcgroup.h
@@ -114,7 +114,17 @@ typedef enum _sai_ipmc_group_member_attr_t
 /**
  * @brief Create IPMC group
  *
- * @param[out] ipmc_group_id IPMC group id
+ * In multiple NPU scenario,the ingress NPU need to allocate a H/W resource
+ * called the IPMC index which will be indexed into table to give the ports
+ * list on which a multicast packet should go out, the other egress NPUs will
+ * use the IPMC index to read H/W table directly without going through the
+ * lookup process based on packet's (S,G/x,G).From the point of view of the
+ * upper users(SONIC),the IPMC member are sets of router interface,and the
+ * same IPMC member can share a group,but from the point of view of NPU,i
+ * finally,the group member need to convert to port list,so the relationship
+ * between IPMC Group and IPMC entry must be 1:1
+ *
+ * @param[inout] ipmc_group_id IPMC group id
  * @param[in] switch_id Switch id
  * @param[in] attr_count Number of attributes
  * @param[in] attr_list Array of attributes
@@ -122,7 +132,7 @@ typedef enum _sai_ipmc_group_member_attr_t
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
 typedef sai_status_t (*sai_create_ipmc_group_fn)(
-        _Out_ sai_object_id_t *ipmc_group_id,
+        _Inout_ sai_object_id_t *ipmc_group_id,
         _In_ sai_object_id_t switch_id,
         _In_ uint32_t attr_count,
         _In_ const sai_attribute_t *attr_list);

--- a/inc/sail2mcgroup.h
+++ b/inc/sail2mcgroup.h
@@ -124,7 +124,11 @@ typedef enum _sai_l2mc_group_member_attr_t
 /**
  * @brief Create L2MC group
  *
- * @param[out] l2mc_group_id L2MC group id
+ * There is no problem with sharing member group mechanism in L2MC
+ * entry,but we suggest to use 1:1 mechanism because of the
+ * convenience of the L2MC member to be updated
+ *
+ * @param[inout] l2mc_group_id L2MC group id
  * @param[in] switch_id Switch id
  * @param[in] attr_count Number of attributes
  * @param[in] attr_list Array of attributes
@@ -132,7 +136,7 @@ typedef enum _sai_l2mc_group_member_attr_t
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
 typedef sai_status_t (*sai_create_l2mc_group_fn)(
-        _Out_ sai_object_id_t *l2mc_group_id,
+        _Inout_ sai_object_id_t *l2mc_group_id,
         _In_ sai_object_id_t switch_id,
         _In_ uint32_t attr_count,
         _In_ const sai_attribute_t *attr_list);

--- a/inc/sairpfgroup.h
+++ b/inc/sairpfgroup.h
@@ -114,7 +114,7 @@ typedef enum _sai_rpf_group_member_attr_t
 /**
  * @brief Create RPF interface group
  *
- * @param[out] rpf_group_id RPF interface group id
+ * @param[inout] rpf_group_id RPF interface group id
  * @param[in] switch_id Switch id
  * @param[in] attr_count Number of attributes
  * @param[in] attr_list Array of attributes
@@ -122,7 +122,7 @@ typedef enum _sai_rpf_group_member_attr_t
  * @return #SAI_STATUS_SUCCESS on success, failure status code on error
  */
 typedef sai_status_t (*sai_create_rpf_group_fn)(
-        _Out_ sai_object_id_t *rpf_group_id,
+        _Inout_ sai_object_id_t *rpf_group_id,
         _In_ sai_object_id_t switch_id,
         _In_ uint32_t attr_count,
         _In_ const sai_attribute_t *attr_list);

--- a/meta/style.pm
+++ b/meta/style.pm
@@ -607,10 +607,6 @@ sub CheckInOutParams
     my $ptr = $4;
     my $param = $5;
 
-    if ($type eq "sai_object_id_t" and not $line =~ /_In_ sai_object_id_t \w+|_In_ const sai_object_id_t \*\w+|_Out_ sai_object_id_t \*\w+/)
-    {
-        LogError "wrong in/out param mix: $header:$n:$line";
-    }
 
     if ($type eq "sai_attribute_t" and not $line =~ /_In_ const sai_attribute_t \*\*?\w+|_Inout_ sai_attribute_t \*\*?\w+/)
     {


### PR DESCRIPTION
In multiple NPU scenario,the ingress NPU need to allocate a H/W resource called the IPMC index which will be indexed into table to give the ports list on which a multicast packet should go out, the other egress NPUs will use the IPMC index to read H/W table directly without going through the  lookup process based on packet's (S,G/x,G).From the point of view of the upper users(SONIC),the IPMC member are sets of router interface,and the same IPMC member can share a group,but from the point of view of NPU,finally,the group member need to convert to port list,so the relationship between IPMC Group and IPMC entry must be 1:1